### PR TITLE
Add the yum-epel::default recipe if at least one yum-ius repository managed

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -31,6 +31,8 @@
   ius-dev-source
  }.each do |repo|
   if node['yum'][repo]['managed']
+    include_recipe 'yum-epel' unless run_context.loaded_recipe?('yum-epel')
+
     yum_repository repo do
       description node['yum'][repo]['description']
       baseurl node['yum'][repo]['baseurl']


### PR DESCRIPTION
I'm a bit surprised this wasn't already done, as yum-ius already depends on yum-epel.

IUS packages usually require EPEL repository to already be set up, which is why ius-release RPM package requires epel-release package, so the recipe should really be including the recipe to set up EPEL repositories.
