### PR TITLE
New mirrorlist

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,8 +5,9 @@ provisioner:
   name: chef_zero
 
 platforms:
-  - name: centos-5.10
-  - name: centos-6.5
+  - name: centos-5.11
+  - name: centos-6.6
+  - name: centos-7.1
 
 suites:
   - name: default

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -22,3 +22,6 @@ Style/FileName:
 # Configuration parameters: EnforcedStyle, MinBodyLength, SupportedStyles.
 Style/Next:
   Enabled: false
+
+Style/RegexpLiteral:
+  AllowInnerSlashes: true

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-site 'https://supermarket.chef.io'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,13 @@ source 'https://rubygems.org'
 
 group :lint do
   gem 'foodcritic', '~> 3.0'
-  gem 'rubocop', '~> 0.18'
+  gem 'rubocop', '~> 0.31'
   gem 'rainbow', '< 2.0'
 end
 
 group :unit do
-  gem 'berkshelf',  '~> 3.0.0.beta6'
-  gem 'chefspec',   '~> 4.0'
+  gem 'berkshelf',  '~> 3.2'
+  gem 'chefspec',   '~> 4.2'
 end
 
 group :kitchen_common do

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ default['yum']['ius']['failovermethod'] = 'priority'
 default['yum']['ius']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius']['gpgcheck'] = true
 default['yum']['ius']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch'
-default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6&arch=$basearch'
+default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -36,7 +36,7 @@ default['yum']['ius-debuginfo']['failovermethod'] = 'priority'
 default['yum']['ius-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-debuginfo']['gpgcheck'] = true
 default['yum']['ius-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Debug'
-default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-debuginfo&arch=$basearch'
+default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-debuginfo&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -47,7 +47,7 @@ default['yum']['ius-source']['failovermethod'] = 'priority'
 default['yum']['ius-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-source']['gpgcheck'] = true
 default['yum']['ius-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Source'
-default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-source&arch=$basearch'
+default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-source&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -58,7 +58,7 @@ default['yum']['ius-archive']['failovermethod'] = 'priority'
 default['yum']['ius-archive']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive']['gpgcheck'] = true
 default['yum']['ius-archive']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Archive'
-default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-archive&arch=$basearch'
+default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-archive&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -69,7 +69,7 @@ default['yum']['ius-archive-debuginfo']['failovermethod'] = 'priority'
 default['yum']['ius-archive-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive-debuginfo']['gpgcheck'] = true
 default['yum']['ius-archive-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Archive Debug'
-default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-debuginfo&arch=$basearch'
+default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-debuginfo&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -80,7 +80,7 @@ default['yum']['ius-archive-source']['failovermethod'] = 'priority'
 default['yum']['ius-archive-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive-source']['gpgcheck'] = true
 default['yum']['ius-archive-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Archive Source'
-default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-source&arch=$basearch'
+default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-source&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -91,7 +91,7 @@ default['yum']['ius-testing']['failovermethod'] = 'priority'
 default['yum']['ius-testing']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-testing']['gpgcheck'] = true
 default['yum']['ius-testing']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Testing'
-default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-testing&arch=$basearch'
+default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-testing&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -102,7 +102,7 @@ default['yum']['ius-testing-debuginfo']['failovermethod'] = 'priority'
 default['yum']['ius-testing-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-testing-debuginfo']['gpgcheck'] = true
 default['yum']['ius-testing-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Testing Debug'
-default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-debuginfo&arch=$basearch'
+default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-debuginfo&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -113,7 +113,7 @@ default['yum']['ius-testing-source']['failovermethod'] = 'priority'
 default['yum']['ius-testing-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-testing-source']['gpgcheck'] = true
 default['yum']['ius-testing-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Testing Source'
-default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-source&arch=$basearch'
+default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-source&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -124,7 +124,7 @@ default['yum']['ius-dev']['failovermethod'] = 'priority'
 default['yum']['ius-dev']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-dev']['gpgcheck'] = true
 default['yum']['ius-dev']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Dev'
-default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-dev&arch=$basearch'
+default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-dev&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -135,7 +135,7 @@ default['yum']['ius-dev-debuginfo']['failovermethod'] = 'priority'
 default['yum']['ius-dev-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-dev-debuginfo']['gpgcheck'] = true
 default['yum']['ius-dev-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Dev Debug Info'
-default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-debuginfo&arch=$basearch'
+default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-debuginfo&arch=$basearch&protocol=http'
 ```
 
 ``` ruby
@@ -146,7 +146,7 @@ default['yum']['ius-dev-source']['failovermethod'] = 'priority'
 default['yum']['ius-dev-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-dev-source']['gpgcheck'] = true
 default['yum']['ius-dev-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Dev Source'
-default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-source&arch=$basearch'
+default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-source&arch=$basearch&protocol=http'
 ```
 
 
@@ -158,7 +158,7 @@ Recipes
 
 ```ruby
   yum_repository 'ius' do
-    mirrorlist 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6&arch=$basearch'
+    mirrorlist 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6&arch=$basearch&protocol=http'
     description 'IUS Community Packages for Enterprise Linux 6 - $basearch'
     enabled true
     gpgcheck true

--- a/attributes/ius-archive-debuginfo.rb
+++ b/attributes/ius-archive-debuginfo.rb
@@ -18,19 +18,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-archive-debuginfo&arch=$basearch'
+    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-archive-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-debuginfo&arch=$basearch'
+    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-archive-debuginfo&arch=$basearch'
+    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-archive-debuginfo&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-archive-debuginfo&arch=$basearch'
+    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-archive-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-archive-debuginfo&arch=$basearch'
+    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-archive-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-archive-debuginfo&arch=$basearch'
+    default['yum']['ius-archive-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-archive-debuginfo&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-archive-debuginfo.rb
+++ b/attributes/ius-archive-debuginfo.rb
@@ -2,7 +2,7 @@ default['yum']['ius-archive-debuginfo']['repositoryid'] = 'ius-archive-debuginfo
 default['yum']['ius-archive-debuginfo']['enabled'] = false
 default['yum']['ius-archive-debuginfo']['managed'] = false
 default['yum']['ius-archive-debuginfo']['failovermethod'] = 'priority'
-default['yum']['ius-archive-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-archive-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive-debuginfo']['gpgcheck'] = true
 
 case node['platform_version'].to_i

--- a/attributes/ius-archive-debuginfo.rb
+++ b/attributes/ius-archive-debuginfo.rb
@@ -4,6 +4,10 @@ default['yum']['ius-archive-debuginfo']['managed'] = false
 default['yum']['ius-archive-debuginfo']['failovermethod'] = 'priority'
 default['yum']['ius-archive-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive-debuginfo']['gpgcheck'] = true
+case node['platform_version'].to_i
+when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
 
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-archive-source.rb
+++ b/attributes/ius-archive-source.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-archive-source&arch=$basearch'
+    default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-archive-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-source&arch=$basearch'
+    default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-archive-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-archive-source&arch=$basearch'
+    default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-archive-source&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-archive-source&arch=$basearch'
+    default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-archive-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-archive-source&arch=$basearch'
+    default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-archive-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-archive-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-archive-source&arch=$basearch'
+    default['yum']['ius-archive-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-archive-source&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-archive-source.rb
+++ b/attributes/ius-archive-source.rb
@@ -6,6 +6,11 @@ default['yum']['ius-archive-source']['gpgkey'] = 'https://dl.iuscommunity.org/pu
 default['yum']['ius-archive-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-archive-source']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Archive Source'
 when 6
   default['yum']['ius-archive-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Archive Source'

--- a/attributes/ius-archive-source.rb
+++ b/attributes/ius-archive-source.rb
@@ -2,7 +2,7 @@ default['yum']['ius-archive-source']['repositoryid'] = 'ius-archive-source'
 default['yum']['ius-archive-source']['enabled'] = false
 default['yum']['ius-archive-source']['managed'] = false
 default['yum']['ius-archive-source']['failovermethod'] = 'priority'
-default['yum']['ius-archive-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-archive-source']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-archive.rb
+++ b/attributes/ius-archive.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-archive&arch=$basearch'
+    default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-archive&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-archive&arch=$basearch'
+    default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-archive&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-archive&arch=$basearch'
+    default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-archive&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-archive&arch=$basearch'
+    default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-archive&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-archive&arch=$basearch'
+    default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-archive&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-archive']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-archive&arch=$basearch'
+    default['yum']['ius-archive']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-archive&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-archive.rb
+++ b/attributes/ius-archive.rb
@@ -2,7 +2,7 @@ default['yum']['ius-archive']['repositoryid'] = 'ius-archive'
 default['yum']['ius-archive']['enabled'] = false
 default['yum']['ius-archive']['managed'] = false
 default['yum']['ius-archive']['failovermethod'] = 'priority'
-default['yum']['ius-archive']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-archive']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-archive']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-archive.rb
+++ b/attributes/ius-archive.rb
@@ -6,6 +6,11 @@ default['yum']['ius-archive']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/I
 default['yum']['ius-archive']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-archive']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Archive'
 when 6
   default['yum']['ius-archive']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Archive'

--- a/attributes/ius-debuginfo.rb
+++ b/attributes/ius-debuginfo.rb
@@ -2,7 +2,7 @@ default['yum']['ius-debuginfo']['repositoryid'] = 'ius-debuginfo'
 default['yum']['ius-debuginfo']['enabled'] = false
 default['yum']['ius-debuginfo']['managed'] = false
 default['yum']['ius-debuginfo']['failovermethod'] = 'priority'
-default['yum']['ius-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-debuginfo']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-debuginfo.rb
+++ b/attributes/ius-debuginfo.rb
@@ -6,6 +6,11 @@ default['yum']['ius-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius
 default['yum']['ius-debuginfo']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Debug'
 when 6
   default['yum']['ius-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Debug'

--- a/attributes/ius-debuginfo.rb
+++ b/attributes/ius-debuginfo.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-debuginfo&arch=$basearch'
+    default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-debuginfo&arch=$basearch'
+    default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-debuginfo&arch=$basearch'
+    default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-debuginfo&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-debuginfo&arch=$basearch'
+    default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-debuginfo&arch=$basearch'
+    default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-debuginfo&arch=$basearch'
+    default['yum']['ius-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-debuginfo&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-dev-debuginfo.rb
+++ b/attributes/ius-dev-debuginfo.rb
@@ -6,6 +6,11 @@ default['yum']['ius-dev-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub
 default['yum']['ius-dev-debuginfo']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-dev-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Dev Debug Info'
 when 6
   default['yum']['ius-dev-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Dev Debug Info'

--- a/attributes/ius-dev-debuginfo.rb
+++ b/attributes/ius-dev-debuginfo.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-dev-debuginfo&arch=$basearch'
+    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-dev-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-debuginfo&arch=$basearch'
+    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-dev-debuginfo&arch=$basearch'
+    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-dev-debuginfo&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-dev-debuginfo&arch=$basearch'
+    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-dev-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-dev-debuginfo&arch=$basearch'
+    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-dev-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-dev-debuginfo&arch=$basearch'
+    default['yum']['ius-dev-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-dev-debuginfo&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-dev-debuginfo.rb
+++ b/attributes/ius-dev-debuginfo.rb
@@ -2,7 +2,7 @@ default['yum']['ius-dev-debuginfo']['repositoryid'] = 'ius-dev-debuginfo'
 default['yum']['ius-dev-debuginfo']['enabled'] = false
 default['yum']['ius-dev-debuginfo']['managed'] = false
 default['yum']['ius-dev-debuginfo']['failovermethod'] = 'priority'
-default['yum']['ius-dev-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-dev-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-dev-debuginfo']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-dev-source.rb
+++ b/attributes/ius-dev-source.rb
@@ -2,7 +2,7 @@ default['yum']['ius-dev-source']['repositoryid'] = 'ius-dev-source'
 default['yum']['ius-dev-source']['enabled'] = false
 default['yum']['ius-dev-source']['managed'] = false
 default['yum']['ius-dev-source']['failovermethod'] = 'priority'
-default['yum']['ius-dev-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-dev-source']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-dev-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-dev-source.rb
+++ b/attributes/ius-dev-source.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-dev-source&arch=$basearch'
+    default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-dev-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-source&arch=$basearch'
+    default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-dev-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-dev-source&arch=$basearch'
+    default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-dev-source&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-dev-source&arch=$basearch'
+    default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-dev-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-dev-source&arch=$basearch'
+    default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-dev-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-dev-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-dev-source&arch=$basearch'
+    default['yum']['ius-dev-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-dev-source&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-dev-source.rb
+++ b/attributes/ius-dev-source.rb
@@ -6,6 +6,11 @@ default['yum']['ius-dev-source']['gpgkey'] = 'https://dl.iuscommunity.org/pub/iu
 default['yum']['ius-dev-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-dev-source']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Dev Source'
 when 6
   default['yum']['ius-dev-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Dev Source'

--- a/attributes/ius-dev.rb
+++ b/attributes/ius-dev.rb
@@ -6,6 +6,11 @@ default['yum']['ius-dev']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-C
 default['yum']['ius-dev']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-dev']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Dev'
 when 6
   default['yum']['ius-dev']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Dev'

--- a/attributes/ius-dev.rb
+++ b/attributes/ius-dev.rb
@@ -2,7 +2,7 @@ default['yum']['ius-dev']['repositoryid'] = 'ius-dev'
 default['yum']['ius-dev']['enabled'] = false
 default['yum']['ius-dev']['managed'] = false
 default['yum']['ius-dev']['failovermethod'] = 'priority'
-default['yum']['ius-dev']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-dev']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-dev']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-dev.rb
+++ b/attributes/ius-dev.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-dev&arch=$basearch'
+    default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-dev&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-dev&arch=$basearch'
+    default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-dev&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-dev&arch=$basearch'
+    default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-dev&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-dev&arch=$basearch'
+    default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-dev&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-dev&arch=$basearch'
+    default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-dev&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-dev']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-dev&arch=$basearch'
+    default['yum']['ius-dev']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-dev&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-source.rb
+++ b/attributes/ius-source.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-source&arch=$basearch'
+    default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-source&arch=$basearch'
+    default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-source&arch=$basearch'
+    default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-source&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-source&arch=$basearch'
+    default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-source&arch=$basearch'
+    default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-source&arch=$basearch'
+    default['yum']['ius-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-source&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-source.rb
+++ b/attributes/ius-source.rb
@@ -2,7 +2,7 @@ default['yum']['ius-source']['repositoryid'] = 'ius-source'
 default['yum']['ius-source']['enabled'] = false
 default['yum']['ius-source']['managed'] = false
 default['yum']['ius-source']['failovermethod'] = 'priority'
-default['yum']['ius-source']['gpgkey'] = 'http://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-source']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-source.rb
+++ b/attributes/ius-source.rb
@@ -6,6 +6,11 @@ default['yum']['ius-source']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IU
 default['yum']['ius-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-source']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Source'
 when 6
   default['yum']['ius-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Source'

--- a/attributes/ius-testing-debuginfo.rb
+++ b/attributes/ius-testing-debuginfo.rb
@@ -6,6 +6,11 @@ default['yum']['ius-testing-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org
 default['yum']['ius-testing-debuginfo']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-testing-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Testing Debug'
 when 6
   default['yum']['ius-testing-debuginfo']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Testing Debug'

--- a/attributes/ius-testing-debuginfo.rb
+++ b/attributes/ius-testing-debuginfo.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-testing-debuginfo&arch=$basearch'
+    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-testing-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-debuginfo&arch=$basearch'
+    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-testing-debuginfo&arch=$basearch'
+    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-testing-debuginfo&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-testing-debuginfo&arch=$basearch'
+    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-testing-debuginfo&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-testing-debuginfo&arch=$basearch'
+    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-testing-debuginfo&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-testing-debuginfo&arch=$basearch'
+    default['yum']['ius-testing-debuginfo']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-testing-debuginfo&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-testing-debuginfo.rb
+++ b/attributes/ius-testing-debuginfo.rb
@@ -2,7 +2,7 @@ default['yum']['ius-testing-debuginfo']['repositoryid'] = 'ius-testing-debuginfo
 default['yum']['ius-testing-debuginfo']['enabled'] = false
 default['yum']['ius-testing-debuginfo']['managed'] = false
 default['yum']['ius-testing-debuginfo']['failovermethod'] = 'priority'
-default['yum']['ius-testing-debuginfo']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-testing-debuginfo']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-testing-debuginfo']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-testing-source.rb
+++ b/attributes/ius-testing-source.rb
@@ -2,7 +2,7 @@ default['yum']['ius-testing-source']['repositoryid'] = 'ius-testing-source'
 default['yum']['ius-testing-source']['enabled'] = false
 default['yum']['ius-testing-source']['managed'] = false
 default['yum']['ius-testing-source']['failovermethod'] = 'priority'
-default['yum']['ius-testing-source']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-testing-source']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-testing-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-testing-source.rb
+++ b/attributes/ius-testing-source.rb
@@ -6,6 +6,11 @@ default['yum']['ius-testing-source']['gpgkey'] = 'https://dl.iuscommunity.org/pu
 default['yum']['ius-testing-source']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-testing-source']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Testing Source'
 when 6
   default['yum']['ius-testing-source']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Testing Source'

--- a/attributes/ius-testing-source.rb
+++ b/attributes/ius-testing-source.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-testing-source&arch=$basearch'
+    default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-testing-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-source&arch=$basearch'
+    default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-testing-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-testing-source&arch=$basearch'
+    default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-testing-source&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-testing-source&arch=$basearch'
+    default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-testing-source&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-testing-source&arch=$basearch'
+    default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-testing-source&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-testing-source']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-testing-source&arch=$basearch'
+    default['yum']['ius-testing-source']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-testing-source&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius-testing.rb
+++ b/attributes/ius-testing.rb
@@ -6,6 +6,11 @@ default['yum']['ius-testing']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/I
 default['yum']['ius-testing']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius-testing']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch Testing'
 when 6
   default['yum']['ius-testing']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch Testing'

--- a/attributes/ius-testing.rb
+++ b/attributes/ius-testing.rb
@@ -2,7 +2,7 @@ default['yum']['ius-testing']['repositoryid'] = 'ius-testing'
 default['yum']['ius-testing']['enabled'] = false
 default['yum']['ius-testing']['managed'] = false
 default['yum']['ius-testing']['failovermethod'] = 'priority'
-default['yum']['ius-testing']['gpgkey'] = 'http://mirror.its.dal.ca/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius-testing']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius-testing']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius-testing.rb
+++ b/attributes/ius-testing.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5-testing&arch=$basearch'
+    default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5-testing&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6-testing&arch=$basearch'
+    default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6-testing&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7-testing&arch=$basearch'
+    default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7-testing&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5-testing&arch=$basearch'
+    default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5-testing&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6-testing&arch=$basearch'
+    default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6-testing&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius-testing']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7-testing&arch=$basearch'
+    default['yum']['ius-testing']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7-testing&arch=$basearch&protocol=http'
   end
 end

--- a/attributes/ius.rb
+++ b/attributes/ius.rb
@@ -2,7 +2,7 @@ default['yum']['ius']['repositoryid'] = 'ius'
 default['yum']['ius']['enabled'] = true
 default['yum']['ius']['managed'] = true
 default['yum']['ius']['failovermethod'] = 'priority'
-default['yum']['ius']['gpgkey'] = 'http://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
+default['yum']['ius']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY'
 default['yum']['ius']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5

--- a/attributes/ius.rb
+++ b/attributes/ius.rb
@@ -6,6 +6,11 @@ default['yum']['ius']['gpgkey'] = 'https://dl.iuscommunity.org/pub/ius/IUS-COMMU
 default['yum']['ius']['gpgcheck'] = true
 case node['platform_version'].to_i
 when 5
+  default['yum']['ius-archive-debuginfo']['sslverify'] = false
+end
+
+case node['platform_version'].to_i
+when 5
   default['yum']['ius']['description'] = 'IUS Community Packages for Enterprise Linux 5 - $basearch'
 when 6
   default['yum']['ius']['description'] = 'IUS Community Packages for Enterprise Linux 6 - $basearch'

--- a/attributes/ius.rb
+++ b/attributes/ius.rb
@@ -17,19 +17,19 @@ case node['platform']
 when 'redhat'
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el5&arch=$basearch'
+    default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el5&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el6&arch=$basearch'
+    default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el6&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-el7&arch=$basearch'
+    default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-el7&arch=$basearch&protocol=http'
   end
 else
   case node['platform_version'].to_i
   when 5
-    default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos5&arch=$basearch'
+    default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos5&arch=$basearch&protocol=http'
   when 6
-    default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos6&arch=$basearch'
+    default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos6&arch=$basearch&protocol=http'
   when 7
-    default['yum']['ius']['mirrorlist'] = 'http://dmirr.iuscommunity.org/mirrorlist/?repo=ius-centos7&arch=$basearch'
+    default['yum']['ius']['mirrorlist'] = 'https://mirrors.iuscommunity.org/mirrorlist/?repo=ius-centos7&arch=$basearch&protocol=http'
   end
 end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -75,7 +75,7 @@ describe 'yum-ius::default' do
       it "creates yum_repository[#{repo}] with Redhat repo used in mirrorlist" do
         mirror_repo = repo.sub('ius', 'ius-el6')
         expect(chef_run).to create_yum_repository(repo).with(
-          :mirrorlist => "http://dmirr.iuscommunity.org/mirrorlist/?repo=#{mirror_repo}&arch=$basearch"
+          :mirrorlist => "https://mirrors.iuscommunity.org/mirrorlist/?repo=#{mirror_repo}&arch=$basearch&protocol=http"
         )
       end
     end
@@ -116,7 +116,7 @@ describe 'yum-ius::default' do
       it "creates yum_repository[#{repo}] with CentOS repo used in mirrorlist" do
         mirror_repo = repo.sub('ius', 'ius-centos6')
         expect(chef_run).to create_yum_repository(repo).with(
-          :mirrorlist => "http://dmirr.iuscommunity.org/mirrorlist/?repo=#{mirror_repo}&arch=$basearch"
+          :mirrorlist => "https://mirrors.iuscommunity.org/mirrorlist/?repo=#{mirror_repo}&arch=$basearch&protocol=http"
         )
       end
     end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 
 describe 'yum-ius::default' do
   context 'yum-ius::default uses default attributes' do
-
     let(:chef_run) do
       ChefSpec::SoloRunner.new do |node|
         node.set['yum']['ius']['managed'] = true

--- a/test/integration/default/bats/install_a_package.bats
+++ b/test/integration/default/bats/install_a_package.bats
@@ -1,3 +1,3 @@
 @test "install a package" {
-  sudo yum -y install php56u-pgsql
+  sudo yum -y install yum-plugin-replace
 }


### PR DESCRIPTION
IUS have switched to a new mirrorlist server (whilst maintaining BC for the old mirrorlist url)

This gives it the ability to use HTTPS mirrorlist, however SSL verification fails on CentOS 5.11. The mirrorlist will return http base urls, however packages are signed by the gpgkey so are not able to be tampered.

The gpgkey is also available on HTTPS, so should be used to prevent MITM injecting their own key

The Rubocop/Chefspec/Test-Kitchen work needed fixing in order to work with some previous untested changes. I've not updated the Digital Ocean test-kitchen configuration though, as don't want to use my own account to test it.