### PR TITLE
IUS does not support Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The yum-ius cookbook takes over management of the default repositoryids that shi
 ## Requirements
 ### Platforms
 - RHEL/CentOS and derivatives
-- Fedora
 
 ### Chef
 - Chef 11+

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,6 +11,6 @@ depends 'yum-epel'
 source_url 'https://github.com/chef-cookbooks/yum-ius' if respond_to?(:source_url)
 issues_url 'https://github.com/chef-cookbooks/yum-ius/issues' if respond_to?(:issues_url)
 
-%w(amazon centos fedora oracle redhat scientific).each do |os|
+%w(amazon centos oracle redhat scientific).each do |os|
   supports os
 end


### PR DESCRIPTION
IUS does not support Fedora.  I don't have experience with Chef, so I am not sure I made all the needed changes.  Please let me know if further changes are needed.  