### PR TITLE
Add warning for use of EL 5 variants as IUS is ending support as of M…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of the yum-ius cookbook.
 
+## 2.2.0 (UNRELEASED)
+
+- Remove use of releasever to eliminate centos-release dependency.
+- Add warning for use of EL 5 variants as IUS is ending support as of March 31, 2017 following the RHEL EOL of RHEL 5.
+
 ## 2.1.0 (2016-12-22)
 
 - Allow the use of any valid property via attributes

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+Chef::Log.warn 'IUS no longer supports EL 5 packages as RHEL 5 has been EOLed.' if node['platform_version'].to_i == 5
+
 node['yum-ius']['repos'].each do |repo|
   next unless node['yum'][repo]['managed']
   include_recipe 'yum-epel' unless run_context.loaded_recipe?('yum-epel')


### PR DESCRIPTION
### Description

Add warning for use of EL 5 variants as IUS is ending support as of M…arch 31, 2017 following the RHEL EOL of RHEL 5.

Signed-off-by: Jennifer Davis <iennae@gmail.com>

### Issues Resolved

Issue #12 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
